### PR TITLE
Immutable actuals

### DIFF
--- a/chai-immutable.js
+++ b/chai-immutable.js
@@ -71,7 +71,7 @@ module.exports = function (chai, utils) {
     return function (collection) {
       var obj = this._obj;
 
-      if (obj && obj instanceof Collection) {
+      if (obj && obj instanceof Collection || collection instanceof Collection) {
         this.assert(
           Immutable.is(obj, collection),
           'expected #{this} to equal #{exp}',
@@ -437,7 +437,7 @@ module.exports = function (chai, utils) {
    */
 
   assert.equal = function (actual, expected) {
-    if (actual instanceof Collection) {
+    if (actual instanceof Collection || expected instanceof Collection) {
       return new Assertion(actual).equal(expected);
     }
     else return assert.equal;

--- a/test/test.js
+++ b/test/test.js
@@ -36,7 +36,8 @@ describe('chai-immutable', function () {
       it(
         'fails when only the "expected" value is an Immutable collection',
         function () {
-          assert.throws(expect([]).to.equal.bind(null, List()));
+          var fn = function () { expect([]).to.equal(List()); };
+          expect(fn).to.throw(Error);
         }
       );
 
@@ -307,7 +308,8 @@ describe('chai-immutable', function () {
       it(
         'fails when only the "expected" value is an Immutable collection',
         function () {
-          assert.throws(assert.equal.bind(null, [], List()));
+          var fn = function () { assert.equal([], List()); };
+          expect(fn).to.throw(Error);
         }
       );
 

--- a/test/test.js
+++ b/test/test.js
@@ -33,6 +33,13 @@ describe('chai-immutable', function () {
     });
 
     describe('equal method', function () {
+      it(
+        'fails when only the "expected" value is an Immutable collection',
+        function () {
+          assert.throws(expect([]).to.equal.bind(null, List()));
+        }
+      );
+
       it('should be true when compared structure is equal', function () {
         expect(list3).to.equal(List.of(1, 2, 3));
       });
@@ -297,6 +304,13 @@ describe('chai-immutable', function () {
 
   describe('TDD interface', function () {
     describe('equal assertion', function () {
+      it(
+        'fails when only the "expected" value is an Immutable collection',
+        function () {
+          assert.throws(assert.equal.bind(null, [], List()));
+        }
+      );
+
       it('should be true when compared structure is equal', function () {
         assert.equal(list3, List.of(1, 2, 3));
       });


### PR DESCRIPTION
We're getting some false positives in our equals comparisons!

Turns out it's because `Immutable.is` is only used when the "actual" value is an Immutable collection. This fixes it.