### PR TITLE
Fix broken assert.equal assertion when not applied on a Collection

### DIFF
--- a/chai-immutable.js
+++ b/chai-immutable.js
@@ -416,6 +416,7 @@ module.exports = function (chai, utils) {
    */
 
   var assert = chai.assert;
+  var originalEqual = assert.equal;
 
   /**
    * ### .equal(actual, expected)
@@ -437,10 +438,15 @@ module.exports = function (chai, utils) {
    */
 
   assert.equal = function (actual, expected) {
+    /*
+     * It seems like we shouldn't actually need this check, however,
+     * `assert.equal` actually behaves differently than its BDD counterpart!
+     * Namely, the BDD version is strict while the "assert" one isn't.
+     */
     if (actual instanceof Collection) {
       return new Assertion(actual).equal(expected);
     }
-    else return assert.equal;
+    else return originalEqual(actual, expected);
   };
 
   /**

--- a/test/test.js
+++ b/test/test.js
@@ -34,7 +34,7 @@ describe('chai-immutable', function () {
 
     describe('equal method', function () {
       it(
-        'fails when only the "expected" value is an Immutable collection',
+        'should fail when only the "expected" value is an Immutable collection',
         function () {
           var fn = function () { expect([]).to.equal(List()); };
           expect(fn).to.throw(Error);
@@ -306,10 +306,10 @@ describe('chai-immutable', function () {
   describe('TDD interface', function () {
     describe('equal assertion', function () {
       it(
-        'fails when only the "expected" value is an Immutable collection',
+        'should fail when only the "expected" value is an Immutable collection',
         function () {
           var fn = function () { assert.equal([], List()); };
-          expect(fn).to.throw(Error);
+          assert.throw(fn);
         }
       );
 

--- a/test/test.js
+++ b/test/test.js
@@ -33,6 +33,14 @@ describe('chai-immutable', function () {
     });
 
     describe('equal method', function () {
+      it(
+        'fails when only the "expected" value is an Immutable collection',
+        function () {
+          var fn = function () { expect([]).to.equal(List()); };
+          expect(fn).to.throw(Error);
+        }
+      );
+
       it('should be true when compared structure is equal', function () {
         expect(list3).to.equal(List.of(1, 2, 3));
       });
@@ -297,6 +305,14 @@ describe('chai-immutable', function () {
 
   describe('TDD interface', function () {
     describe('equal assertion', function () {
+      it(
+        'fails when only the "expected" value is an Immutable collection',
+        function () {
+          var fn = function () { assert.equal([], List()); };
+          expect(fn).to.throw(Error);
+        }
+      );
+
       it('should be true when compared structure is equal', function () {
         assert.equal(list3, List.of(1, 2, 3));
       });


### PR DESCRIPTION
This is an updated version of #16. I dug into the problem a little deeper to get a better understanding and figured out the actual root cause (essentially, not calling the original `equal` function.