### PR TITLE
Use Iterable.isIterable for Immutable check

### DIFF
--- a/chai-immutable.js
+++ b/chai-immutable.js
@@ -24,6 +24,13 @@
 
     var Assertion = chai.Assertion;
 
+    function assertIsIterable(obj) {
+      new Assertion(obj).assert(
+        Immutable.Iterable.isIterable(obj),
+        'expected #{this} to be an Iterable'
+      );
+    }
+
     /**
      * ## BDD API Reference
      */
@@ -46,7 +53,7 @@
       return function () {
         var obj = this._obj;
 
-        if (obj && obj instanceof Collection) {
+        if (Immutable.Iterable.isIterable(obj)) {
           var size = obj.size;
           new Assertion(size).a('number');
 
@@ -96,7 +103,7 @@
       return function (collection) {
         var obj = this._obj;
 
-        if (obj && obj instanceof Collection) {
+        if (Immutable.Iterable.isIterable(obj)) {
           this.assert(
             Immutable.is(obj, collection),
             'expected #{act} to equal #{exp}',
@@ -141,7 +148,7 @@
       return function (val) {
         var obj = this._obj;
 
-        if (obj && obj instanceof Collection) {
+        if (Immutable.Iterable.isIterable(obj)) {
           this.assert(
             obj.includes(val),
             'expected #{act} to include #{exp}',
@@ -217,14 +224,13 @@
 
         var obj = this._obj;
 
-        if (obj && obj instanceof KeyedCollection) {
+        if (Immutable.Iterable.isKeyed(obj)) {
           switch (utils.type(keys)) {
             case 'object':
-              if (keys instanceof IndexedCollection ||
-                  keys instanceof SetCollection) {
+              if (Immutable.Iterable.isIndexed(keys))
                 keys = keys.toJS();
-              }
-              else if (keys instanceof KeyedCollection) keys = keys.keySeq().toJS();
+              else if (Immutable.Iterable.isIterable(keys))
+                keys = keys.keySeq().toJS();
               else keys = Object.keys(keys);
             case 'array':
               if (arguments.length > 1) throw new Error(
@@ -309,7 +315,7 @@
      */
 
     function assertCollectionSize(n) {
-      new Assertion(this._obj).instanceof(Collection);
+      assertIsIterable(this._obj);
 
       var size = this._obj.size;
       new Assertion(size).a('number');
@@ -335,7 +341,7 @@
     function assertCollectionSizeLeast(_super) {
       return function (n) {
         if (utils.flag(this, 'immutable.collection.size')) {
-          new Assertion(this._obj).instanceof(Collection);
+          assertIsIterable(this._obj);
 
           var size = this._obj.size;
           new Assertion(size).a('number');
@@ -355,7 +361,7 @@
     function assertCollectionSizeMost(_super) {
       return function (n) {
         if (utils.flag(this, 'immutable.collection.size')) {
-          new Assertion(this._obj).instanceof(Collection);
+          assertIsIterable(this._obj);
 
           var size = this._obj.size;
           new Assertion(size).a('number');
@@ -375,7 +381,7 @@
     function assertCollectionSizeAbove(_super) {
       return function (n) {
         if (utils.flag(this, 'immutable.collection.size')) {
-          new Assertion(this._obj).instanceof(Collection);
+          assertIsIterable(this._obj);
 
           var size = this._obj.size;
           new Assertion(size).a('number');
@@ -395,7 +401,7 @@
     function assertCollectionSizeBelow(_super) {
       return function (n) {
         if (utils.flag(this, 'immutable.collection.size')) {
-          new Assertion(this._obj).instanceof(Collection);
+          assertIsIterable(this._obj);
 
           var size = this._obj.size;
           new Assertion(size).a('number');
@@ -429,7 +435,7 @@
     Assertion.overwriteMethod('within', function (_super) {
       return function (min, max) {
         if (utils.flag(this, 'immutable.collection.size')) {
-          new Assertion(this._obj).instanceof(Collection);
+          assertIsIterable(this._obj);
 
           var size = this._obj.size;
           new Assertion(size).a('number');
@@ -483,7 +489,7 @@
       // It seems like we shouldn't actually need this check, however,
       // `assert.equal` actually behaves differently than its BDD counterpart!
       // Namely, the BDD version is strict while the "assert" one isn't.
-      if (actual instanceof Collection) {
+      if (Immutable.Iterable.isIterable(actual)) {
         return new Assertion(actual).equal(expected);
       }
       else return originalEqual(actual, expected);
@@ -509,7 +515,7 @@
      */
 
     assert.notEqual = function (actual, expected) {
-      if (actual instanceof Collection) {
+      if (Immutable.Iterable.isIterable(actual)) {
         return new Assertion(actual).not.equal(expected);
       }
       else return originalNotEqual(actual, expected);

--- a/test/test.js
+++ b/test/test.js
@@ -1,5 +1,15 @@
 'use strict';
 
+// From http://stackoverflow.com/a/728694
+function clone(obj) {
+  if (null === obj || 'object' !== typeof obj) return obj;
+  var copy = obj.constructor();
+  for (var attr in obj) {
+    if (obj.hasOwnProperty(attr)) copy[attr] = obj[attr];
+  }
+  return copy;
+}
+
 var typeEnv;
 if (!chai) {
   var chai = require('chai');
@@ -10,6 +20,8 @@ if (!chai) {
   typeEnv = 'Node.js';
 }
 else typeEnv = 'PhantomJS';
+
+var clonedImmutable = clone(Immutable);
 
 var assert = chai.assert;
 var expect = chai.expect;
@@ -45,6 +57,8 @@ describe('chai-immutable (' + typeEnv + ')', function () {
     list: List.of(42)
   });
 
+  var clonedImmutableList = clonedImmutable.List.of(1, 2, 3);
+
   describe('BDD interface', function () {
     describe('empty property', function () {
       it('should pass given an empty collection', function () {
@@ -67,6 +81,10 @@ describe('chai-immutable (' + typeEnv + ')', function () {
 
       it('should fail using `not` given an empty collection', function () {
         fail(function () { expect(new List()).to.not.be.empty; });
+      });
+
+      it('should work if using different copies of Immutable', function () {
+        expect(clonedImmutable.List()).to.be.empty;
       });
     });
 
@@ -161,6 +179,10 @@ describe('chai-immutable (' + typeEnv + ')', function () {
         fail(function () { expect(deepMap).to.not.eql(sameDeepMap); });
         fail(function () { expect(deepMap).to.not.eqls(sameDeepMap); });
         fail(function () { expect(deepMap).to.not.deep.equal(sameDeepMap); });
+      });
+
+      it('should work if using different copies of Immutable', function () {
+        expect(clonedImmutableList).to.equal(List.of(1, 2, 3));
       });
     });
 
@@ -376,6 +398,10 @@ describe('chai-immutable (' + typeEnv + ')', function () {
         fail(function () { expect(map).to.contain.key('z'); });
         fail(function () { expect(obj).to.contain.key('z'); });
       });
+
+      it('should work if using different copies of Immutable', function () {
+        expect(clonedImmutable.Map({ x: 1 })).to.have.key('x');
+      });
     });
 
     describe('size method', function () {
@@ -398,6 +424,10 @@ describe('chai-immutable (' + typeEnv + ')', function () {
 
       it('should fail using `not` given the right size', function () {
         fail(function () { expect(list3).to.not.have.size(3); });
+      });
+
+      it('should work if using different copies of Immutable', function () {
+        expect(clonedImmutableList).to.have.size(3);
       });
     });
 
@@ -530,6 +560,10 @@ describe('chai-immutable (' + typeEnv + ')', function () {
       it('most should fail using `not` given a bad max size', function () {
         fail(function () { expect(list3).to.not.have.size.of.at.most(42); });
       });
+
+      it('should work if using different copies of Immutable', function () {
+        expect(clonedImmutableList).to.have.size.above(2);
+      });
     });
   });
 
@@ -568,6 +602,10 @@ describe('chai-immutable (' + typeEnv + ')', function () {
       it('should fail given deeply different values', function () {
         fail(function () { assert.equal(deepMap, differentDeepMap); });
       });
+
+      it('should work if using different copies of Immutable', function () {
+        assert.equal(clonedImmutableList, List.of(1, 2, 3));
+      });
     });
 
     describe('notEqual assertion', function () {
@@ -595,6 +633,10 @@ describe('chai-immutable (' + typeEnv + ')', function () {
       it('should fail given deeply equal values', function () {
         fail(function () { assert.notEqual(deepMap, sameDeepMap); });
       });
+
+      it('should work if using different copies of Immutable', function () {
+        assert.notEqual(clonedImmutableList, List.of());
+      });
     });
 
     describe('unoverridden strictEqual and deepEqual assertions', function () {
@@ -616,6 +658,11 @@ describe('chai-immutable (' + typeEnv + ')', function () {
       it('should fail given deeply different values', function () {
         fail(function () { assert.strictEqual(deepMap, differentDeepMap); });
         fail(function () { assert.deepEqual(deepMap, differentDeepMap); });
+      });
+
+      it('should work if using different copies of Immutable', function () {
+        assert.strictEqual(clonedImmutableList, List.of(1, 2, 3));
+        assert.deepEqual(clonedImmutableList, List.of(1, 2, 3));
       });
     });
 
@@ -639,6 +686,11 @@ describe('chai-immutable (' + typeEnv + ')', function () {
         fail(function () { assert.notStrictEqual(deepMap, sameDeepMap); });
         fail(function () { assert.notDeepEqual(deepMap, sameDeepMap); });
       });
+
+      it('should work if using different copies of Immutable', function () {
+        assert.notStrictEqual(clonedImmutableList, List());
+        assert.notDeepEqual(clonedImmutableList, List());
+      });
     });
 
     describe('sizeOf assertion', function () {
@@ -652,6 +704,10 @@ describe('chai-immutable (' + typeEnv + ')', function () {
 
       it('should fail given the wrong size', function () {
         fail(function () { assert.sizeOf(list3, 42); });
+      });
+
+      it('should work if using different copies of Immutable', function () {
+        assert.sizeOf(clonedImmutableList, 3);
       });
     });
   });


### PR DESCRIPTION
Right now the check for whether an object is Immutable uses `instanceof Collection`, which returns false if different modules are using different copies of Immutable.

This PR replaces that with `Immutable.Iterable.isIterable` as advised here: http://stackoverflow.com/questions/31907470/how-to-check-if-object-is-immutable