### PR TITLE
Allow passing immutable values in the property assertion

### DIFF
--- a/chai-immutable.js
+++ b/chai-immutable.js
@@ -396,8 +396,16 @@
           }
 
           if (arguments.length > 1) {
+            var isEqual;
+            if (Immutable.Iterable.isIterable(val)) {
+              isEqual = Immutable.is(val, value);
+            }
+            else {
+              isEqual = val === value;
+            }
+
             this.assert(
-              val === value,
+              isEqual,
               'expected #{this} to have a ' + descriptor + utils.inspect(path) +
                 ' of #{exp}, but got #{act}',
               'expected #{this} not to have a ' + descriptor + utils.inspect(path) +

--- a/test/test.js
+++ b/test/test.js
@@ -506,6 +506,16 @@ describe('chai-immutable (' + typeEnv + ')', function () {
         expect(obj).not.to.have.deep.property(['y', 'x'], 'different');
       });
 
+      it('should pass given an immutable value', function () {
+        var obj = Immutable.fromJS({ foo: { bar: 42 } });
+        expect(obj).to.have.property('foo', new Map({ bar: 42 }));
+      });
+
+      it('should pass using `deep` given an immutable value', function () {
+        var obj = Immutable.fromJS({ foo: [{ bar: 42 }] });
+        expect(obj).to.have.deep.property('foo[0]', new Map({ bar: 42 }));
+      });
+
       it('should allow access to property via .that', function () {
         var obj = Immutable.fromJS({ x: 1, y: { x: 2, y: 3 } });
         var sub = obj.get('y');


### PR DESCRIPTION
Consider the following immutable object:

```js
var obj = new Map({
  items: new List([
    new Map({ name: 'Jane' }),
    new Map({ name: 'John' }),
  ])
});
```

Without this change, the following passes:

```js
expect(obj).to.have.deep.property('items[0].name', 'Jane');
```

But the following fails:

```js
expect(obj).to.have.deep.property('items[1]', new Map({ name: 'Alice'}));
```

Which is a bit too bad for a library that offers assertions for immutable structures!

@scottnonnenberg, considering you contributed to this code, would you mind giving me your opinion and 👍 if you like it? :-)
Thanks!