### PR TITLE
Use friendly object representation in more places

### DIFF
--- a/chai-immutable.js
+++ b/chai-immutable.js
@@ -22,8 +22,17 @@
     function assertIsIterable(obj) {
       new Assertion(obj).assert(
         Immutable.Iterable.isIterable(obj),
-        'expected #{this} to be an Iterable'
+        'expected #{act} to be an Iterable',
+        null,
+        friendlyString(obj)
       );
+    }
+
+    function friendlyString(obj) {
+      if (Immutable.Iterable.isIterable(obj)) {
+        return obj.inspect();
+      }
+      return obj;
     }
 
     /**
@@ -55,8 +64,10 @@
 
           this.assert(
             size === 0,
-            'expected #{this} to be empty but got size #{act}',
-            'expected #{this} to not be empty'
+            'expected #{act} to be empty but got size ' + size,
+            'expected #{act} to not be empty',
+            0,
+            friendlyString(obj)
           );
         }
         else _super.apply(this, arguments);
@@ -105,8 +116,8 @@
             Immutable.is(obj, collection),
             'expected #{act} to equal #{exp}',
             'expected #{act} to not equal #{exp}',
-            collection.toString(),
-            obj.toString(),
+            friendlyString(collection),
+            friendlyString(obj),
             true
           );
         }
@@ -151,8 +162,8 @@
             obj.includes(val),
             'expected #{act} to include #{exp}',
             'expected #{act} to not include #{exp}',
-            val,
-            obj.toString()
+            friendlyString(val),
+            friendlyString(obj)
           );
         }
         else _super.apply(this, arguments);
@@ -271,7 +282,7 @@
             'expected #{act} to ' + str,
             'expected #{act} to not ' + str,
             keys,
-            obj.toString()
+            friendlyString(obj)
           );
         }
         else _super.apply(this, arguments);
@@ -451,8 +462,10 @@
           else {
             this.assert(
               hasProperty,
-              'expected #{this} to have a ' + descriptor + utils.inspect(path),
-              'expected #{this} not to have ' + descriptor + utils.inspect(path)
+              'expected #{act} to have a ' + descriptor + '#{exp}',
+              'expected #{act} not to have ' + descriptor + '#{exp}',
+              path,
+              friendlyString(obj)
             );
           }
 
@@ -471,8 +484,8 @@
                 ' of #{exp}, but got #{act}',
               'expected #{this} not to have a ' + descriptor + utils.inspect(path) +
                 ' of #{act}',
-              val,
-              value
+              friendlyString(val),
+              friendlyString(value)
             );
           }
 

--- a/test/test.js
+++ b/test/test.js
@@ -79,6 +79,19 @@ describe('chai-immutable (' + typeEnv + ')', function () {
         fail(function () { expect(list3).to.be.empty; });
       });
 
+      it('should display helpful output', function () {
+        fail(function () { expect(list3).to.be.empty; }, list3.inspect());
+        fail(function () { expect(list3).to.be.empty; }, 'size 3');
+      });
+
+      it('should display a helpful failure output on big objects', function () {
+        var lengthyMap = new Map({ foo: 'foo foo foo foo foo foo foo foo' });
+        fail(
+          function () { expect(lengthyMap).to.be.empty; },
+          lengthyMap.inspect()
+        );
+      });
+
       it('should fail using `not` given an empty collection', function () {
         fail(function () { expect(new List()).to.not.be.empty; });
       });
@@ -230,6 +243,13 @@ describe('chai-immutable (' + typeEnv + ')', function () {
         fail(function () {
           expect(lengthyMap).to.include('not-foo');
         }, /(foo ){8}/);
+      });
+
+      it('should display a helpful failure on the value too', function () {
+        var lengthyMap = new Map({ foo: 'foo foo foo foo foo foo foo foo ' });
+        fail(function () {
+          expect(Set.of()).to.include(lengthyMap);
+        }, lengthyMap.inspect());
       });
 
       it('should fail given an inexisting value', function () {
@@ -412,6 +432,21 @@ describe('chai-immutable (' + typeEnv + ')', function () {
       it('should fail given an inexisting property', function () {
         var obj = Immutable.fromJS({ x: 1 });
         fail(function () { expect(obj).to.have.property('z'); });
+      });
+
+      it('should have a helpful message for inexisting property', function () {
+        var lengthyMap = new Map({ foo: 'foo foo foo foo foo foo foo foo ' });
+        fail(
+          function () { expect(lengthyMap).to.have.property('not-foo'); },
+          lengthyMap.inspect()
+        );
+      });
+
+      it('should have a helpful message including the path', function () {
+        var lengthyMap = new Map({ foo: 'foo foo foo foo foo foo foo foo ' });
+        fail(function () {
+          expect(lengthyMap).to.have.property(['bar', 'baz', 'bar', 'baz']);
+        }, /bar.*baz.*bar.*baz/);
       });
 
       it('should pass using `not` given an inexisting property', function () {


### PR DESCRIPTION
I ran into a couple of places recently where I had representations like `{ Object (_map) }` in my failure messages, most notably in the `.include` method.

In this PR I've tried to use the custom representation in more places, and expanded tests to cover.

I've also raised https://github.com/chaijs/chai/issues/727 upstream to see if there's a better general solution.