### PR TITLE
Better diff output when comparing

### DIFF
--- a/chai-immutable.js
+++ b/chai-immutable.js
@@ -105,8 +105,8 @@
             Immutable.is(obj, collection),
             'expected #{act} to equal #{exp}',
             'expected #{act} to not equal #{exp}',
-            collection.toString(),
-            obj.toString(),
+            collection.toJS(),
+            obj.toJS(),
             true
           );
         }

--- a/test/test.js
+++ b/test/test.js
@@ -146,9 +146,16 @@ describe('chai-immutable (' + typeEnv + ')', function () {
       it('should display a helpful failure output on big objects', function () {
         var actual = new Map({ foo: 'foo foo foo foo foo foo foo foo' });
         var expected = new Map({ bar: 'bar bar bar bar bar bar bar bar' });
+        // AssertionError: expected { Object (foo) } to equal { Object (bar) }
+        // + expected - actual
+        //
+        //  {
+        // -  "foo": "foo foo foo foo foo foo foo foo"
+        // +  "bar": "bar bar bar bar bar bar bar bar"
+        //  }
         fail(function () {
           expect(actual).to.equal(expected);
-        }, /(foo ?){8}.+(bar ?){8}/);
+        }, 'AssertionError: expected { Object (foo) } to equal { Object (bar) }');
       });
 
       it('should fail given a non-Immutable value', function () {
@@ -749,9 +756,16 @@ describe('chai-immutable (' + typeEnv + ')', function () {
       it('should display a helpful failure output on big objects', function () {
         var actual = new Map({ foo: 'foo foo foo foo foo foo foo foo ' });
         var expected = new Map({ bar: 'bar bar bar bar bar bar bar bar ' });
+        // AssertionError: expected { Object (foo) } to equal { Object (bar) }
+        // + expected - actual
+        //
+        //  {
+        // -  "foo": "foo foo foo foo foo foo foo foo"
+        // +  "bar": "bar bar bar bar bar bar bar bar"
+        //  }
         fail(function () {
           assert.equal(actual, expected);
-        }, /(foo ){8}.+(bar ){8}/);
+        }, 'AssertionError: expected { Object (foo) } to equal { Object (bar) }');
       });
 
       it('should fail given a non-Immutable value', function () {


### PR DESCRIPTION
This shows a better diff of which keys are extra/missing rather than getting big strings dumped on the user
