### PR TITLE
Update for Chai v4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ expect(new Map({ foo: 1, bar: 2 })).to.contain.key('foo');
 Asserts that the target has a property `name`, optionally asserting that
 the value of that property is equal to `value`. `value` can be an
 Immutable object.
-If the `deep` flag is set, you can use dot- and bracket-notation for deep
+If the `nested` flag is set, you can use dot- and bracket-notation for nested
 references into objects and arrays.
 
 <!-- fulky:define maps -->
@@ -184,23 +184,23 @@ expect(map).to.have.property('foo');
 expect(map).to.have.property('foo', 'bar');
 
 // Deep referencing
-var deepMap = new Map({
+var nestedMap = new Map({
   green: new Map({ tea: 'matcha' }),
   teas: new List(['chai', 'matcha', new Map({ tea: 'konacha' })])
 });
 
-expect(deepMap).to.have.deep.property('green.tea', 'matcha');
-expect(deepMap).to.have.deep.property(['green', 'tea'], 'matcha');
-expect(deepMap).to.have.deep.property(new List(['green', 'tea']), 'matcha');
-expect(deepMap).to.have.deep.property('teas[1]', 'matcha');
-expect(deepMap).to.have.deep.property(['teas', 1], 'matcha');
-expect(deepMap).to.have.deep.property(new List(['teas', 1]), 'matcha');
-expect(deepMap).to.have.deep.property('teas[2].tea', 'konacha');
-expect(deepMap).to.have.deep.property(['teas', 2, 'tea'], 'konacha');
-expect(deepMap).to.have.deep.property(new List(['teas', 2, 'tea']), 'konacha');
+expect(nestedMap).to.have.nested.property('green.tea', 'matcha');
+expect(nestedMap).to.have.nested.property(['green', 'tea'], 'matcha');
+expect(nestedMap).to.have.nested.property(new List(['green', 'tea']), 'matcha');
+expect(nestedMap).to.have.nested.property('teas[1]', 'matcha');
+expect(nestedMap).to.have.nested.property(['teas', 1], 'matcha');
+expect(nestedMap).to.have.nested.property(new List(['teas', 1]), 'matcha');
+expect(nestedMap).to.have.nested.property('teas[2].tea', 'konacha');
+expect(nestedMap).to.have.nested.property(['teas', 2, 'tea'], 'konacha');
+expect(nestedMap).to.have.nested.property(new List(['teas', 2, 'tea']), 'konacha');
 ```
 
-You can also use a `List` as the starting point of a `deep.property`
+You can also use a `List` as the starting point of a `nested.property`
 assertion, or traverse nested `List`s.
 
 ```js
@@ -213,12 +213,12 @@ var list = new List([
   ])
 ]);
 
-expect(list).to.have.deep.property('[0][1]', 'matcha');
-expect(list).to.have.deep.property([0, 1], 'matcha');
-expect(list).to.have.deep.property(new List([0, 1]), 'matcha');
-expect(list).to.have.deep.property('[1][2].tea', 'konacha');
-expect(list).to.have.deep.property([1, 2, 'tea'], 'konacha');
-expect(list).to.have.deep.property(new List([1, 2, 'tea']), 'konacha');
+expect(list).to.have.nested.property('[0][1]', 'matcha');
+expect(list).to.have.nested.property([0, 1], 'matcha');
+expect(list).to.have.nested.property(new List([0, 1]), 'matcha');
+expect(list).to.have.nested.property('[1][2].tea', 'konacha');
+expect(list).to.have.nested.property([1, 2, 'tea'], 'konacha');
+expect(list).to.have.nested.property(new List([1, 2, 'tea']), 'konacha');
 ```
 
 Furthermore, `property` changes the subject of the assertion
@@ -229,17 +229,17 @@ permits for further chainable assertions on that property.
 ```js
 expect(map).to.have.property('foo')
   .that.is.a('string');
-expect(deepMap).to.have.property('green')
+expect(nestedMap).to.have.property('green')
   .that.is.an.instanceof(Map)
   .that.equals(new Map({ tea: 'matcha' }));
-expect(deepMap).to.have.property('teas')
+expect(nestedMap).to.have.property('teas')
   .that.is.an.instanceof(List)
-  .with.deep.property([2])
+  .with.nested.property([2])
     .that.equals(new Map({ tea: 'konacha' }));
 ```
 
 Note that dots and brackets in `name` must be backslash-escaped when
-the `deep` flag is set, while they must NOT be escaped when the `deep`
+the `nested` flag is set, while they must NOT be escaped when the `nested`
 flag is not set.
 
 ```js
@@ -248,8 +248,8 @@ var css = new Map({ '.link[target]': 42 });
 expect(css).to.have.property('.link[target]', 42);
 
 // Deep referencing
-var deepCss = new Map({ '.link': new Map({ '[target]': 42 }) });
-expect(deepCss).to.have.deep.property('\\.link.\\[target\\]', 42);
+var nestedCss = new Map({ '.link': new Map({ '[target]': 42 }) });
+expect(nestedCss).to.have.nested.property('\\.link.\\[target\\]', 42);
 ```
 
 ### .size(value)

--- a/chai-immutable.js
+++ b/chai-immutable.js
@@ -225,13 +225,13 @@
 
         if (Immutable.Iterable.isKeyed(obj)) {
           switch (utils.type(keys)) {
-            case 'object':
+            case 'Object':
               if (Immutable.Iterable.isIndexed(keys))
                 keys = keys.toJS();
               else if (Immutable.Iterable.isIterable(keys))
                 keys = keys.keySeq().toJS();
               else keys = Object.keys(keys);
-            case 'array':
+            case 'Array':
               if (arguments.length > 1) throw new Error(
                 'keys must be given single argument of ' +
                 'Array|Object|String|Collection, ' +
@@ -253,7 +253,7 @@
           if (any) ok = keys.some(has);
           else {
             ok = keys.every(has);
-            if (!contains && !utils.flag(this, 'negate')) {
+            if (!contains) {
               ok = ok && keys.length === obj.count();
             }
           }
@@ -331,8 +331,8 @@
      * Asserts that the target has a property `name`, optionally asserting that
      * the value of that property is equal to `value`. `value` can be an
      * Immutable object.
-     * If the `deep` flag is set, you can use dot- and bracket-notation for deep
-     * references into objects and arrays.
+     * If the `nested` flag is set, you can use dot- and bracket-notation for
+     * nested references into objects and arrays.
      *
      * ```js
      * // Simple referencing
@@ -341,23 +341,23 @@
      * expect(map).to.have.property('foo', 'bar');
      *
      * // Deep referencing
-     * var deepMap = new Map({
+     * var nestedMap = new Map({
      *     green: new Map({ tea: 'matcha' }),
      *     teas: new List(['chai', 'matcha', new Map({ tea: 'konacha' })])
      * });
      *
-     * expect(deepMap).to.have.deep.property('green.tea', 'matcha');
-     * expect(deepMap).to.have.deep.property(['green', 'tea'], 'matcha');
-     * expect(deepMap).to.have.deep.property(new List(['green', 'tea']), 'matcha');
-     * expect(deepMap).to.have.deep.property('teas[1]', 'matcha');
-     * expect(deepMap).to.have.deep.property(['teas', 1], 'matcha');
-     * expect(deepMap).to.have.deep.property(new List(['teas', 1]), 'matcha');
-     * expect(deepMap).to.have.deep.property('teas[2].tea', 'konacha');
-     * expect(deepMap).to.have.deep.property(['teas', 2, 'tea'], 'konacha');
-     * expect(deepMap).to.have.deep.property(new List(['teas', 2, 'tea']), 'konacha');
+     * expect(nestedMap).to.have.nested.property('green.tea', 'matcha');
+     * expect(nestedMap).to.have.nested.property(['green', 'tea'], 'matcha');
+     * expect(nestedMap).to.have.nested.property(new List(['green', 'tea']), 'matcha');
+     * expect(nestedMap).to.have.nested.property('teas[1]', 'matcha');
+     * expect(nestedMap).to.have.nested.property(['teas', 1], 'matcha');
+     * expect(nestedMap).to.have.nested.property(new List(['teas', 1]), 'matcha');
+     * expect(nestedMap).to.have.nested.property('teas[2].tea', 'konacha');
+     * expect(nestedMap).to.have.nested.property(['teas', 2, 'tea'], 'konacha');
+     * expect(nestedMap).to.have.nested.property(new List(['teas', 2, 'tea']), 'konacha');
      * ```
      *
-     * You can also use a `List` as the starting point of a `deep.property`
+     * You can also use a `List` as the starting point of a `nested.property`
      * assertion, or traverse nested `List`s.
      *
      * ```js
@@ -370,12 +370,12 @@
      *   ])
      * ]);
      *
-     * expect(list).to.have.deep.property('[0][1]', 'matcha');
-     * expect(list).to.have.deep.property([0, 1], 'matcha');
-     * expect(list).to.have.deep.property(new List([0, 1]), 'matcha');
-     * expect(list).to.have.deep.property('[1][2].tea', 'konacha');
-     * expect(list).to.have.deep.property([1, 2, 'tea'], 'konacha');
-     * expect(list).to.have.deep.property(new List([1, 2, 'tea']), 'konacha');
+     * expect(list).to.have.nested.property('[0][1]', 'matcha');
+     * expect(list).to.have.nested.property([0, 1], 'matcha');
+     * expect(list).to.have.nested.property(new List([0, 1]), 'matcha');
+     * expect(list).to.have.nested.property('[1][2].tea', 'konacha');
+     * expect(list).to.have.nested.property([1, 2, 'tea'], 'konacha');
+     * expect(list).to.have.nested.property(new List([1, 2, 'tea']), 'konacha');
      * ```
      *
      * Furthermore, `property` changes the subject of the assertion
@@ -385,18 +385,18 @@
      * ```js
      * expect(map).to.have.property('foo')
      *   .that.is.a('string');
-     * expect(deepMap).to.have.property('green')
+     * expect(nestedMap).to.have.property('green')
      *   .that.is.an.instanceof(Map)
      *   .that.equals(new Map({ tea: 'matcha' }));
-     * expect(deepMap).to.have.property('teas')
+     * expect(nestedMap).to.have.property('teas')
      *   .that.is.an.instanceof(List)
-     *   .with.deep.property([2])
+     *   .with.nested.property([2])
      *     .that.equals(new Map({ tea: 'konacha' }));
      * ```
      *
      * Note that dots and brackets in `name` must be backslash-escaped when
-     * the `deep` flag is set, while they must NOT be escaped when the `deep`
-     * flag is not set.
+     * the `nested` flag is set, while they must NOT be escaped when the
+     * `nested` flag is not set.
      *
      * ```js
      * // Simple referencing
@@ -404,8 +404,8 @@
      * expect(css).to.have.property('.link[target]', 42);
      *
      * // Deep referencing
-     * var deepCss = new Map({ '.link': new Map({ '[target]': 42 }) });
-     * expect(deepCss).to.have.deep.property('\\.link.\\[target\\]', 42);
+     * var nestedCss = new Map({ '.link': new Map({ '[target]': 42 }) });
+     * expect(nestedCss).to.have.nested.property('\\.link.\\[target\\]', 42);
      * ```
      *
      * @name property
@@ -419,15 +419,15 @@
         var obj = this._obj;
 
         if (Immutable.Iterable.isIterable(this._obj)) {
-          var isDeep = Boolean(utils.flag(this, 'deep'));
+          var isNested = Boolean(utils.flag(this, 'nested'));
           var negate = Boolean(utils.flag(this, 'negate'));
 
           var descriptor;
           var hasProperty;
           var value;
 
-          if (isDeep) {
-            descriptor = 'deep property ';
+          if (isNested) {
+            descriptor = 'nested property ';
             if (typeof path === 'string') {
               path = parsePath(path);
             }

--- a/package.json
+++ b/package.json
@@ -37,10 +37,10 @@
   },
   "homepage": "https://github.com/astorije/chai-immutable",
   "peerDependencies": {
-    "chai": ">= 2.0.0 < 4"
+    "chai": "^4.0.0"
   },
   "devDependencies": {
-    "chai": "^3.4.0",
+    "chai": "^4.0.0",
     "coveralls": "^2.11.9",
     "fulky": "^0.1.0",
     "immutable": "^3.7.5",

--- a/test/test.js
+++ b/test/test.js
@@ -359,11 +359,6 @@ describe('chai-immutable (' + typeEnv + ')', function () {
         fail(function () { expect({ x: 1 }).to.have.key('z'); });
       });
 
-      it('should fail using `not` given an inexisting key', function () {
-        fail(function () { expect(map).to.not.have.key('x'); });
-        fail(function () { expect(obj).to.not.have.key('x'); });
-      });
-
       it('should fail given multiple inexisting keys', function () {
         fail(function () { expect(map).to.have.keys('z1', 'z2'); });
         fail(function () { expect(obj).to.have.keys('z1', 'z2'); });
@@ -450,36 +445,36 @@ describe('chai-immutable (' + typeEnv + ')', function () {
         expect(obj).to.have.property('y').that.equal(sub);
       });
 
-      describe('using the `deep` flag', function () {
+      describe('using the `nested` flag', function () {
         it('should not affect the original assertion', function () {
-          expect({ x: 1, y: { x: 2, y: 3 } }).to.have.deep.property('y.x', 2);
+          expect({ x: 1, y: { x: 2, y: 3 } }).to.have.nested.property('y.x', 2);
         });
 
         it('should fail given an inexisting property', function () {
           var obj = Immutable.fromJS({ x: 1, y: { x: 2, y: 3 } });
-          fail(function () { expect(obj).to.have.deep.property(['y', 'z']); });
+          fail(function () { expect(obj).to.have.nested.property(['y', 'z']); });
         });
 
         it('should pass using `not` given an inexisting property', function () {
           var obj = Immutable.fromJS({ x: 1, y: { x: 2, y: 3 } });
-          expect(obj).not.to.have.deep.property(['y', 'z']);
+          expect(obj).not.to.have.nested.property(['y', 'z']);
         });
 
         it('should pass given an existing property', function () {
           var obj = Immutable.fromJS({ x: 1, y: { x: 2, y: 3 } });
-          expect(obj).to.have.deep.property(['y', 'x']);
+          expect(obj).to.have.nested.property(['y', 'x']);
         });
 
         it('should pass given an index', function () {
           var obj = Immutable.fromJS({
             items: ['a', 'b', 'c'],
           });
-          expect(obj).to.have.deep.property(['items', 2], 'c');
+          expect(obj).to.have.nested.property(['items', 2], 'c');
         });
 
         it('should fail using `not` given an existing property', function () {
           var obj = Immutable.fromJS({ x: 1, y: { x: 2, y: 3 } });
-          fail(function () { expect(obj).not.to.have.deep.property(['y', 'x']); });
+          fail(function () { expect(obj).not.to.have.nested.property(['y', 'x']); });
         });
 
         it('should fail given a property with a bad value', function () {
@@ -491,31 +486,31 @@ describe('chai-immutable (' + typeEnv + ')', function () {
 
         it('should pass given a property with the good value', function () {
           var obj = Immutable.fromJS({ x: 1, y: { x: 2, y: 3 } });
-          expect(obj).to.have.deep.property(['y', 'x'], 2);
+          expect(obj).to.have.nested.property(['y', 'x'], 2);
         });
 
         it('should fail using `not` given an inexisting property', function () {
           var obj = Immutable.fromJS({ x: 1 });
           fail(function () {
-            expect(obj).not.to.have.deep.property(['y', 'x'], 'different');
+            expect(obj).not.to.have.nested.property(['y', 'x'], 'different');
           });
         });
 
         it('should fail using `not` given a property with good value', function () {
           var obj = Immutable.fromJS({ x: 1, y: { x: 2 } });
           fail(function () {
-            expect(obj).not.to.have.deep.property(['y', 'x'], 2);
+            expect(obj).not.to.have.nested.property(['y', 'x'], 2);
           });
         });
 
         it('should pass using `not` given a property with a bad value', function () {
           var obj = Immutable.fromJS({ x: 1, y: { x: 2 } });
-          expect(obj).not.to.have.deep.property(['y', 'x'], 'different');
+          expect(obj).not.to.have.nested.property(['y', 'x'], 'different');
         });
 
         it('should pass given an immutable value', function () {
           var obj = Immutable.fromJS({ foo: [{ bar: 42 }] });
-          expect(obj).to.have.deep.property('foo[0]', new Map({ bar: 42 }));
+          expect(obj).to.have.nested.property('foo[0]', new Map({ bar: 42 }));
         });
       });
 
@@ -528,13 +523,13 @@ describe('chai-immutable (' + typeEnv + ')', function () {
           ],
         });
 
-        it('should pass using `deep` given a single index', function () {
-          expect(obj.get('items')).to.have.deep.property('[1]')
+        it('should pass using `nested` given a single index', function () {
+          expect(obj.get('items')).to.have.nested.property('[1]')
             .that.equals(new Map({ name: 'John' }));
         });
 
-        it('should pass using `deep` given a single key', function () {
-          expect(obj).to.have.deep.property('items')
+        it('should pass using `nested` given a single key', function () {
+          expect(obj).to.have.nested.property('items')
             .that.equals(new List([
               new Map({ name: 'Jane' }),
               new Map({ name: 'John' }),
@@ -542,17 +537,17 @@ describe('chai-immutable (' + typeEnv + ')', function () {
             ]));
         });
 
-        it('should pass using `deep` starting with an index', function () {
-          expect(obj.get('items')).to.have.deep.property('[0].name', 'Jane');
+        it('should pass using `nested` starting with an index', function () {
+          expect(obj.get('items')).to.have.nested.property('[0].name', 'Jane');
         });
 
-        it('should pass using `deep` ending with an index', function () {
-          expect(obj).to.have.deep.property('items[1]')
+        it('should pass using `nested` ending with an index', function () {
+          expect(obj).to.have.nested.property('items[1]')
             .that.equals(new Map({ name: 'John' }));
         });
 
-        it('should pass using `deep` given a mix of keys and indices', function () {
-          expect(obj).to.have.deep.property('items[2].name', 'Jim');
+        it('should pass using `nested` given mix of keys and indices', function () {
+          expect(obj).to.have.nested.property('items[2].name', 'Jim');
         });
 
         it('should expect unescaped path strings', function () {
@@ -560,9 +555,9 @@ describe('chai-immutable (' + typeEnv + ')', function () {
           expect(css).to.have.property('.link[target]', 42);
         });
 
-        it('should expect escaped path strings using `deep`', function () {
-          var deepCss = new Map({ '.link': new Map({ '[target]': 42 }) });
-          expect(deepCss).to.have.deep.property('\\.link.\\[target\\]', 42);
+        it('should expect escaped path strings using `nested`', function () {
+          var nestedCss = new Map({ '.link': new Map({ '[target]': 42 }) });
+          expect(nestedCss).to.have.nested.property('\\.link.\\[target\\]', 42);
         });
       });
     });
@@ -862,14 +857,16 @@ describe('chai-immutable (' + typeEnv + ')', function () {
         fail(function () { assert.property(obj, 'z'); });
       });
 
-      it('should succeed for equal deep property', function () {
+      it('should succeed for equal nested property', function () {
         var obj = Immutable.fromJS({ x: 1, y: { x: 2, y: 3 } });
-        assert.deepProperty(obj, ['y', 'x']);
+        assert.nestedProperty(obj, ['y', 'x']);
       });
 
       it('should fail for unequal deep property', function () {
         var obj = Immutable.fromJS({ x: 1, y: { x: 2, y: 3 } });
-        fail(function () { assert.deepPropertyVal(obj, ['y', 'x'], 'different'); });
+        fail(function () {
+          assert.nestedPropertyVal(obj, ['y', 'x'], 'different');
+        });
       });
     });
 


### PR DESCRIPTION
DO NOT MERGE

Hi @astorije, I'm just going through some Chai plugins to see how much the upcoming Chai v4.0 breaks things (given that it has a number of breaking changes). I noticed one breaking change in this project regarding the `deep.property` assertion being renamed to `nested.property` in Chai v4.0. Also, there's a breaking change in Chai's `type-detect` library regarding capitalization which impacts this plugin.

This PR does the minimum required to get chai-immutable working in Chai v4.0, but doesn't actually update the chai dev dependency since v4.0 isn't officially released yet (thus the failed Travis build.)

BREAKING CHANGE: `deep.property` renamed to `nested.property`