### PR TITLE
Re-enable PhantomJS tests, for what it's worth...

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "check-style": "jscs chai-immutable.js test/test.js",
     "test": "npm run test-mocha; npm run test-phantomjs; npm run check-style",
     "test-mocha": "mocha",
-    "test-phantomjs": "echo 'mocha-phantomjs is temporarily disabled.' # mocha-phantomjs test/index.html",
+    "test-phantomjs": "mocha-phantomjs test/index.html",
     "coverage": "istanbul cover _mocha",
     "coveralls": "npm run coverage && cat ./coverage/lcov.info | coveralls"
   },
@@ -44,6 +44,7 @@
     "immutable": "^3.7.5",
     "istanbul": "^0.4.3",
     "jscs": "^2.5.0",
-    "mocha": "^2.4.5"
+    "mocha": "^2.4.5",
+    "mocha-phantomjs": "^4.1.0"
   }
 }


### PR DESCRIPTION
I am not sure having tests run by `mocha-phantomjs` is really useful as it's not being actually tested in any browser, but since it was already set up before, why not until #27 or equivalent gets set up.

It doesn't test cross-browser compatibility, but at least it tests that the [browser-loading snippet](https://github.com/astorije/chai-immutable/blob/master/chai-immutable.js#L14-L17) doesn't get broken.
