### PR TITLE
Test JS examples in README

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ node_js:
 script:
 - npm run test-mocha
 - npm run test-phantomjs
+- if [[ "$TRAVIS_NODE_VERSION" != "0.1"* ]]; then npm run test-readme; fi
 - npm run check-style
 
 after_script:

--- a/README.md
+++ b/README.md
@@ -10,6 +10,20 @@
 
 This plugin provides a set of [Chai](http://chaijs.com/) assertions for [Facebook's Immutable library for JavaScript collections](http://facebook.github.io/immutable-js/).
 
+<!-- fulky:globals
+var chai = require('chai');
+var assert = chai.assert;
+var expect = chai.expect;
+
+var Immutable = require('immutable');
+var List = Immutable.List;
+var Map = Immutable.Map;
+var Set = Immutable.Set;
+var Stack = Immutable.Stack;
+
+chai.use(require('./chai-immutable'));
+-->
+
 ## Installation
 
 ### Node.js
@@ -22,6 +36,7 @@ npm install chai-immutable
 
 You can then use this plugin as any other Chai plugins:
 
+<!-- fulky:skip-test -->
 ```js
 var chai = require('chai');
 var chaiImmutable = require('chai-immutable');
@@ -45,6 +60,7 @@ If you are using this plugin with
 [`dirty-chai`](https://github.com/prodatakey/dirty-chai), note that
 `chai-immutable` must be loaded **before** any of them. For example:
 
+<!-- fulky:skip-test -->
 ```js
 var chai = require('chai');
 var chaiAsPromised = require('chai-as-promised');
@@ -160,6 +176,7 @@ Immutable object.
 If the `deep` flag is set, you can use dot- and bracket-notation for deep
 references into objects and arrays.
 
+<!-- fulky:define maps -->
 ```js
 // Simple referencing
 var map = new Map({ foo: 'bar' });
@@ -168,8 +185,8 @@ expect(map).to.have.property('foo', 'bar');
 
 // Deep referencing
 var deepMap = new Map({
-    green: new Map({ tea: 'matcha' }),
-    teas: new List(['chai', 'matcha', new Map({ tea: 'konacha' })])
+  green: new Map({ tea: 'matcha' }),
+  teas: new List(['chai', 'matcha', new Map({ tea: 'konacha' })])
 });
 
 expect(deepMap).to.have.deep.property('green.tea', 'matcha');
@@ -208,6 +225,7 @@ Furthermore, `property` changes the subject of the assertion
 to be the value of that property from the original object. This
 permits for further chainable assertions on that property.
 
+<!-- fulky:use maps -->
 ```js
 expect(map).to.have.property('foo')
   .that.is.a('string');

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,6 +25,7 @@ test_script:
   - npm --version
   - npm run test-mocha
   - npm run test-phantomjs
+  - if not "%nodejs_version:~0,3%" == "0.1" npm run test-readme
   - npm run check-style
 
 # Don't actually build

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   },
   "scripts": {
     "check-style": "jscs chai-immutable.js test/test.js",
-    "test": "npm run test-mocha; npm run test-phantomjs; npm run check-style",
+    "test": "npm run test-mocha; npm run test-phantomjs; npm run test-readme; npm run check-style",
+    "test-readme": "mocha --compilers md:fulky/mocha-md-compiler README.md",
     "test-mocha": "mocha",
     "test-phantomjs": "mocha-phantomjs test/index.html",
     "coverage": "istanbul cover _mocha",
@@ -41,6 +42,7 @@
   "devDependencies": {
     "chai": "^3.4.0",
     "coveralls": "^2.11.9",
+    "fulky": "^0.1.0",
     "immutable": "^3.7.5",
     "istanbul": "^0.4.3",
     "jscs": "^2.5.0",


### PR DESCRIPTION
Use https://www.npmjs.com/package/fulky that provides a compiler for Mocha, extracting JavaScript snippets from the README and running them as individual tests.

Fulky is ES6-only, so configurations for Travis CI and AppVeyor are not running it.