### PR TITLE
Fix for message not being displayed in assert methods 

### DIFF
--- a/chai-immutable.js
+++ b/chai-immutable.js
@@ -99,6 +99,7 @@
     function assertCollectionEqual(_super) {
       return function (collection) {
         var obj = this._obj;
+
         if (Immutable.Iterable.isIterable(obj)) {
           this.assert(
             Immutable.is(obj, collection),

--- a/chai-immutable.js
+++ b/chai-immutable.js
@@ -694,7 +694,7 @@
       // `assert.equal` actually behaves differently than its BDD counterpart!
       // Namely, the BDD version is strict while the "assert" one isn't.
       if (Immutable.Iterable.isIterable(actual)) {
-        return new Assertion(actual, message).equal(expected, message);
+        return new Assertion(actual, message).equal(expected);
       }
       else return originalEqual(actual, expected, message);
     };

--- a/chai-immutable.js
+++ b/chai-immutable.js
@@ -99,7 +99,6 @@
     function assertCollectionEqual(_super) {
       return function (collection) {
         var obj = this._obj;
-
         if (Immutable.Iterable.isIterable(obj)) {
           this.assert(
             Immutable.is(obj, collection),
@@ -689,14 +688,14 @@
      * @api public
      */
 
-    assert.equal = function (actual, expected) {
+    assert.equal = function (actual, expected, message) {
       // It seems like we shouldn't actually need this check, however,
       // `assert.equal` actually behaves differently than its BDD counterpart!
       // Namely, the BDD version is strict while the "assert" one isn't.
       if (Immutable.Iterable.isIterable(actual)) {
-        return new Assertion(actual).equal(expected);
+        return new Assertion(actual, message).equal(expected, message);
       }
-      else return originalEqual(actual, expected);
+      else return originalEqual(actual, expected, message);
     };
 
     /**
@@ -719,11 +718,11 @@
      * @api public
      */
 
-    assert.notEqual = function (actual, expected) {
+    assert.notEqual = function (actual, expected, message) {
       if (Immutable.Iterable.isIterable(actual)) {
-        return new Assertion(actual).not.equal(expected);
+        return new Assertion(actual, message).not.equal(expected);
       }
-      else return originalNotEqual(actual, expected);
+      else return originalNotEqual(actual, expected, message);
     };
 
     /**
@@ -743,8 +742,8 @@
      * @api public
      */
 
-    assert.sizeOf = function (collection, expected) {
-      new Assertion(collection).size(expected);
+    assert.sizeOf = function (collection, expected, message) {
+      new Assertion(collection, message).size(expected);
     };
   };
 }));

--- a/test/test.js
+++ b/test/test.js
@@ -770,19 +770,22 @@ describe('chai-immutable (' + typeEnv + ')', function () {
         assert.equal(clonedImmutableList, List.of(1, 2, 3));
       });
 
-      it('should display a custom message if given as argument when failing', function () {
+      it('should display a custom message when failing', function () {
         try {
-          assert.equal(1, 2, "*Custom message*");
-        } catch(e) {
-          assert.equal(e.message, "*Custom message*: expected 1 to equal 2")
+          assert.equal(1, 2, '*Custom message*');
+        }
+        catch (e) {
+          assert.equal(e.message, '*Custom message*: expected 1 to equal 2');
         }
       });
 
-      it('should display a custom message if given as argument when failing - Immutable', function () {
+      it('should display a message when failing - Immutable', function () {
         try {
-          assert.equal(List.of(1, 2), List.of(3, 4), "*Custom message*");
-        } catch(e) {
-          assert.equal(e.message, "*Custom message*: expected \'List [ 1, 2 ]\' to equal \'List [ 3, 4 ]\'")
+          assert.equal(List.of(1, 2), List.of(3, 4), '*Custom message*');
+        }
+        catch (e) {
+          assert.equal(e.message, '*Custom message*: expected \'List [ 1, 2 ]\'' +
+            ' to equal \'List [ 3, 4 ]\'');
         }
       });
     });
@@ -817,19 +820,22 @@ describe('chai-immutable (' + typeEnv + ')', function () {
         assert.notEqual(clonedImmutableList, List.of());
       });
 
-      it('should display a custom message if given as argument when failing', function () {
+      it('should display a message when failing', function () {
         try {
-          assert.notEqual(1, 1, "*Custom message*");
-        } catch(e) {
-          assert.equal(e.message, "*Custom message*: expected 1 to not equal 1")
+          assert.notEqual(1, 1, '*Custom message*');
+        }
+        catch (e) {
+          assert.equal(e.message, '*Custom message*: expected 1 to not equal 1');
         }
       });
 
-      it('should display a custom message if given as argument when failing - Immutable', function () {
+      it('should display a message when failing - Immutable', function () {
         try {
-          assert.notEqual(List.of(1, 2), List.of(3, 4), "*Custom message*");
-        } catch(e) {
-          assert.equal(e.message, "*Custom message*: expected \'List [ 1, 2 ]\' to equal \'List [ 3, 4 ]\'")
+          assert.notEqual(List.of(1, 2), List.of(3, 4), '*Custom message*');
+        }
+        catch (e) {
+          assert.equal(e.message, '*Custom message*: expected \'List [ 1, 2 ]\'' +
+            'to equal \'List [ 3, 4 ]\'');
         }
       });
     });
@@ -922,11 +928,13 @@ describe('chai-immutable (' + typeEnv + ')', function () {
         assert.sizeOf(clonedImmutableList, 3);
       });
 
-      it('should display a custom message if given as argument when failing', function () {
+      it('should display a message when failing', function () {
         try {
           assert.sizeOf(list3, 2, '*Custom message*');
-        } catch(e) {
-          assert.equal(e.message, "*Custom message*: expected List [ 1, 2, 3 ] to have size 2 but got 3")
+        }
+        catch (e) {
+          assert.equal(e.message, '*Custom message*: expected List [ 1, 2, 3 ] ' +
+            'to have size 2 but got 3');
         }
       });
     });

--- a/test/test.js
+++ b/test/test.js
@@ -769,6 +769,22 @@ describe('chai-immutable (' + typeEnv + ')', function () {
       it('should work if using different copies of Immutable', function () {
         assert.equal(clonedImmutableList, List.of(1, 2, 3));
       });
+
+      it('should display a custom message if given as argument when failing', function () {
+        try {
+          assert.equal(1, 2, "*Custom message*");
+        } catch(e) {
+          assert.equal(e.message, "*Custom message*: expected 1 to equal 2")
+        }
+      });
+
+      it('should display a custom message if given as argument when failing - Immutable', function () {
+        try {
+          assert.equal(List.of(1, 2), List.of(3, 4), "*Custom message*");
+        } catch(e) {
+          assert.equal(e.message, "*Custom message*: expected \'List [ 1, 2 ]\' to equal \'List [ 3, 4 ]\'")
+        }
+      });
     });
 
     describe('notEqual assertion', function () {
@@ -799,6 +815,22 @@ describe('chai-immutable (' + typeEnv + ')', function () {
 
       it('should work if using different copies of Immutable', function () {
         assert.notEqual(clonedImmutableList, List.of());
+      });
+
+      it('should display a custom message if given as argument when failing', function () {
+        try {
+          assert.notEqual(1, 1, "*Custom message*");
+        } catch(e) {
+          assert.equal(e.message, "*Custom message*: expected 1 to not equal 1")
+        }
+      });
+
+      it('should display a custom message if given as argument when failing - Immutable', function () {
+        try {
+          assert.notEqual(List.of(1, 2), List.of(3, 4), "*Custom message*");
+        } catch(e) {
+          assert.equal(e.message, "*Custom message*: expected \'List [ 1, 2 ]\' to equal \'List [ 3, 4 ]\'")
+        }
       });
     });
 
@@ -888,6 +920,14 @@ describe('chai-immutable (' + typeEnv + ')', function () {
 
       it('should work if using different copies of Immutable', function () {
         assert.sizeOf(clonedImmutableList, 3);
+      });
+
+      it('should display a custom message if given as argument when failing', function () {
+        try {
+          assert.sizeOf(list3, 2, '*Custom message*');
+        } catch(e) {
+          assert.equal(e.message, "*Custom message*: expected List [ 1, 2, 3 ] to have size 2 but got 3")
+        }
       });
     });
   });


### PR DESCRIPTION
When given as an argument the message should be displayed when the assertion fails like is does when
chai is being used without chai-immutable. 

It has been fixed for these methods:
assert.equal(actual, expected, message)
assert.notEqual(actual, expected, message)
assert.sizeOf(collection, expected, message)