### PR TITLE
Fix tests around AssertionError messages

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -155,7 +155,7 @@ describe('chai-immutable (' + typeEnv + ')', function () {
         //  }
         fail(function () {
           expect(actual).to.equal(expected);
-        }, 'AssertionError: expected { Object (foo) } to equal { Object (bar) }');
+        }, 'expected { Object (foo) } to equal { Object (bar) }');
       });
 
       it('should fail given a non-Immutable value', function () {
@@ -760,7 +760,7 @@ describe('chai-immutable (' + typeEnv + ')', function () {
         //  }
         fail(function () {
           assert.equal(actual, expected);
-        }, 'AssertionError: expected { Object (foo) } to equal { Object (bar) }');
+        }, 'expected { Object (foo) } to equal { Object (bar) }');
       });
 
       it('should fail given a non-Immutable value', function () {


### PR DESCRIPTION
This follows up #67.

I did not investigate much, but I believe there was a change in `Chai`'s `AssertionError` or something in Chai v4 and while #67 passed the tests, I merged it after #69 triggering these failures.