### PR TITLE
Remove mocha-phantomjs test suite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ node_js:
 
 script:
 - npm run test-mocha
-- npm run test-phantomjs
 - npm run test-readme
 - npm run check-style
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,7 +24,6 @@ test_script:
   - node --version
   - npm --version
   - npm run test-mocha
-  - npm run test-phantomjs
   - npm run test-readme
   - npm run check-style
 

--- a/package.json
+++ b/package.json
@@ -8,10 +8,9 @@
   },
   "scripts": {
     "check-style": "jscs chai-immutable.js test/test.js",
-    "test": "npm run test-mocha; npm run test-phantomjs; npm run test-readme; npm run check-style",
+    "test": "npm run test-mocha; npm run test-readme; npm run check-style",
     "test-readme": "mocha --compilers md:fulky/mocha-md-compiler README.md",
     "test-mocha": "nyc mocha",
-    "test-phantomjs": "mocha-phantomjs test/index.html",
     "coveralls": "nyc report --reporter=text-lcov | coveralls"
   },
   "repository": {
@@ -48,7 +47,6 @@
     "immutable": "^3.7.5",
     "jscs": "^2.5.0",
     "mocha": "^2.4.5",
-    "mocha-phantomjs": "^4.1.0",
     "nyc": "^11.3.0"
   }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -10,16 +10,13 @@ function clone(obj) {
   return copy;
 }
 
-var typeEnv;
 if (!chai) {
   var chai = require('chai');
   var chaiImmutable = require('../chai-immutable');
   var Immutable = require('immutable');
 
   chai.use(chaiImmutable);
-  typeEnv = 'Node.js';
 }
-else typeEnv = 'PhantomJS';
 
 var clonedImmutable = clone(Immutable);
 
@@ -39,7 +36,7 @@ function fail(fn, msg) {
   else expect(fn).to.throw(chai.AssertionError);
 }
 
-describe('chai-immutable (' + typeEnv + ')', function () {
+describe('chai-immutable', function () {
   var list3 = List.of(1, 2, 3);
 
   var deepMap = new Map({


### PR DESCRIPTION
At the moment, PhantomJS is not ES6-compatible so a further commit that enables ES6 features is simply breaking it. Furthermore, this is not very useful at the moment, because it merely tests the loading of the plugin in a (headless) browser, nothing more.

I do plan to integrate better testing in browsers, and I do need to re-test the correct loading of these tests in a browser. In the meantime, loading `test/index.html` manually in a browser is a way to do that.