### PR TITLE
Remove AMD check, as it was never supported anyway

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -3,7 +3,6 @@
 root: true
 
 env:
-  amd: true
   commonjs: true
   es6: true
 

--- a/chai-immutable.js
+++ b/chai-immutable.js
@@ -6,9 +6,6 @@
       typeof module === 'object') {
     // Node.js
     module.exports = factory(require('immutable'));
-  } else if (typeof define === 'function' && define.amd) {
-    // AMD
-    throw new Error('chai-immutable is not compatible with an AMD loader yet.');
   } else {
     // Other environments (usually <script> tag)
     context.chai.use(factory(context.Immutable));


### PR DESCRIPTION
Closes #21.
Setting expectations for v2.0.0: `chai-immutable` is supported in Node and the browser. Anything else will need contributions :D