### PR TITLE
Mark Immutable.js as a `peerDependency`

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
   },
   "homepage": "https://github.com/astorije/chai-immutable",
   "peerDependencies": {
-    "chai": "^4.0.0"
+    "chai": "^4.0.0",
+    "immutable": "^3.0.0"
   },
   "devDependencies": {
     "chai": "^4.0.0",


### PR DESCRIPTION
Specifically in version 3: this plugin would not work with < 3 anyway, and v4 has not been released yet.