### PR TITLE
Remove Node.js v9 from the CI matrices

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: node_js
 
 node_js:
   - 10 # EOL: April 2021
-  - 9 # EOL: June 2018
   - 8 # EOL: December 2019
   - 6 # EOL: April 2019
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,7 +9,6 @@ skip_tags: true
 environment:
   matrix:
     - nodejs_version: 10 # EOL: April 2021
-    - nodejs_version: 9 # EOL: June 2018
     - nodejs_version: 8 # EOL: December 2019
     - nodejs_version: 6 # EOL: April 2019
 


### PR DESCRIPTION
See https://github.com/nodejs/Release.