### PR TITLE
include uses isSuperset

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,8 @@ immutable data structures.
 ```js
 expect(new List([1, 2, 3])).to.include(2);
 expect(new List([1, 2, 3])).to.deep.include(2);
+expect(new Map({ foo: 'bar', hello: 'world' })).to.include('bar');
+expect(new Map({ a: 1, b: 2, c: 3 }).to.include(new Map({ a: 1, b: 2 }))
 expect(new Map({ foo: 'bar', hello: 'world' })).to.include.keys('foo');
 ```
 

--- a/README.md
+++ b/README.md
@@ -139,8 +139,8 @@ tested against immutable data structures, therefore they are aliases to
 - **@param** _{ Mixed }_ val
 
 The `include` and `contain` assertions can be used as either property
-based language chains or as methods to assert the inclusion of a value or 
-subset in an immutable collection. When used as language chains, they toggle 
+based language chains or as methods to assert the inclusion of a value or
+subset in an immutable collection. When used as language chains, they toggle
 the `contains` flag for the `keys` assertion.
 
 Note that `deep.include` behaves exactly like `include` in the context of

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ immutable data structures.
 expect(new List([1, 2, 3])).to.include(2);
 expect(new List([1, 2, 3])).to.deep.include(2);
 expect(new Map({ foo: 'bar', hello: 'world' })).to.include('bar');
-expect(new Map({ a: 1, b: 2, c: 3 }).to.include(new Map({ a: 1, b: 2 }))
+expect(new Map({ a: 1, b: 2, c: 3 })).to.include(new Map({ a: 1, b: 2 }));
 expect(new Map({ foo: 'bar', hello: 'world' })).to.include.keys('foo');
 ```
 

--- a/README.md
+++ b/README.md
@@ -139,9 +139,9 @@ tested against immutable data structures, therefore they are aliases to
 - **@param** _{ Mixed }_ val
 
 The `include` and `contain` assertions can be used as either property
-based language chains or as methods to assert the inclusion of a value
-in an immutable collection. When used as language chains, they toggle the
-`contains` flag for the `keys` assertion.
+based language chains or as methods to assert the inclusion of a value or 
+subset in an immutable collection. When used as language chains, they toggle 
+the `contains` flag for the `keys` assertion.
 
 Note that `deep.include` behaves exactly like `include` in the context of
 immutable data structures.

--- a/chai-immutable.js
+++ b/chai-immutable.js
@@ -134,6 +134,8 @@
    * ```js
    * expect(new List([1, 2, 3])).to.include(2);
    * expect(new List([1, 2, 3])).to.deep.include(2);
+   * expect(new Map({ foo: 'bar', hello: 'world' })).to.include('bar');
+   * expect(new Map({ a: 1, b: 2, c: 3 })).to.include(new Map({ a: 1, b: 2 }));
    * expect(new Map({ foo: 'bar', hello: 'world' })).to.include.keys('foo');
    * ```
    *

--- a/chai-immutable.js
+++ b/chai-immutable.js
@@ -151,8 +151,10 @@
       const obj = this._obj;
 
       if (Immutable.Iterable.isIterable(obj)) {
+        const isIncluded = 
+          obj.includes(val) || (Immutable.Iterable.isIterable(val) && obj.isSuperset(val));
         this.assert(
-          obj.includes(val),
+          isIncluded,
           'expected #{act} to include #{exp}',
           'expected #{act} to not include #{exp}',
           val,

--- a/chai-immutable.js
+++ b/chai-immutable.js
@@ -124,7 +124,7 @@
    * ### .include(value)
    *
    * The `include` and `contain` assertions can be used as either property
-   * based language chains or as methods to assert the inclusion of a value or subset 
+   * based language chains or as methods to assert the inclusion of a value or subset
    * in an immutable collection. When used as language chains, they toggle the
    * `contains` flag for the `keys` assertion.
    *

--- a/chai-immutable.js
+++ b/chai-immutable.js
@@ -124,7 +124,7 @@
    * ### .include(value)
    *
    * The `include` and `contain` assertions can be used as either property
-   * based language chains or as methods to assert the inclusion of a value
+   * based language chains or as methods to assert the inclusion of a value or subset 
    * in an immutable collection. When used as language chains, they toggle the
    * `contains` flag for the `keys` assertion.
    *

--- a/chai-immutable.js
+++ b/chai-immutable.js
@@ -151,8 +151,9 @@
       const obj = this._obj;
 
       if (Immutable.Iterable.isIterable(obj)) {
-        const isIncluded = 
-          obj.includes(val) || (Immutable.Iterable.isIterable(val) && obj.isSuperset(val));
+        const isIncluded =
+          obj.includes(val) ||
+          (Immutable.Iterable.isIterable(val) && obj.isSuperset(val));
         this.assert(
           isIncluded,
           'expected #{act} to include #{exp}',

--- a/test/test.js
+++ b/test/test.js
@@ -1028,10 +1028,14 @@ describe('chai-immutable', function() {
         assert.include(map, map1);
         assert.include(map, new Map({ a: 1 }));
       });
+      
+      it('should find plain values', function() {
+        assert.include(map1, 1);
+      })
 
-      it('should not treat partial collections as sub-collections', function() {
-        fail(() => assert.include(map, new Map({ foo: map1 })));
-        fail(() => assert.include(map, new Map({ foo: map1, bar: map2 })));
+      it('should treat partial collections as sub-collections', function() {
+        assert.include(map, new Map({ foo: map1 }));
+        assert.include(map, new Map({ foo: map1, bar: map2 }));
       });
     });
 
@@ -1042,17 +1046,18 @@ describe('chai-immutable', function() {
       const map = new Map({ foo: map1, bar: map2 });
 
       it('should ensure deep equality', function() {
-        assert.notInclude(map, new Map({ foo: map1 }));
-        assert.notInclude(map, new Map({ foo: map1, bar: map2 }));
+        fail(() => assert.notInclude(map, new Map({ foo: map1 })));
+        fail(() => assert.notInclude(map, new Map({ foo: map1, bar: map2 })));
       });
 
-      it('should not treat partial collections as sub-collections', function() {
+      it('should fail for existing collections', function() {
         fail(() => assert.notInclude(list, map1));
         fail(() => assert.notInclude(list, new Map({ a: 1 })));
-
-        fail(() => assert.notInclude(map, map1));
-        fail(() => assert.notInclude(map, new Map({ a: 1 })));
       });
+
+      it('should treat partial overlap as failure', function() {
+        assert.notInclude(map, new Map({foo: new Map({a: 1, b: 2})}));
+      })
     });
 
     describe('property assertions', function() {

--- a/test/test.js
+++ b/test/test.js
@@ -1028,10 +1028,10 @@ describe('chai-immutable', function() {
         assert.include(map, map1);
         assert.include(map, new Map({ a: 1 }));
       });
-      
+
       it('should find plain values', function() {
         assert.include(map1, 1);
-      })
+      });
 
       it('should treat partial collections as sub-collections', function() {
         assert.include(map, new Map({ foo: map1 }));
@@ -1056,8 +1056,8 @@ describe('chai-immutable', function() {
       });
 
       it('should treat partial overlap as failure', function() {
-        assert.notInclude(map, new Map({foo: new Map({a: 1, b: 2})}));
-      })
+        assert.notInclude(map, new Map({ foo: new Map({ a: 1, b: 2 }) }));
+      });
     });
 
     describe('property assertions', function() {


### PR DESCRIPTION
Include now allows immutable subsets as a valid input, making the behavior more like chai's behavior with objects.

References this issue: https://github.com/astorije/chai-immutable/issues/82