### PR TITLE
.equal now checks for isImmutable instead of isIterable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,9 +24,11 @@ notifications:
 
 before_script:
   - 'if [ "$IMMUTABLE_VERSION" ]; then yarn add immutable@$IMMUTABLE_VERSION; fi'
+
 matrix:
   include:
   - env: IMMUTABLE_VERSION=4.0.0-rc.12
+
 # Identifies `a.b.c-xxx.n` tags as pre-releases, and `a.b.c` as stable releases
 before_deploy: |
   function dist_tag() {

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,9 +24,9 @@ notifications:
 
 before_script:
   - 'if [ "$IMMUTABLE_VERSION" ]; then yarn add immutable@$IMMUTABLE_VERSION; fi'
-env:
-  - IMMUTABLE_VERSION=
-  - IMMUTABLE_VERSION=4.0.0-rc.12
+matrix:
+  include:
+  - env: IMMUTABLE_VERSION=4.0.0-rc.12
 # Identifies `a.b.c-xxx.n` tags as pre-releases, and `a.b.c` as stable releases
 before_deploy: |
   function dist_tag() {

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ before_script:
 
 matrix:
   include:
-  - env: IMMUTABLE_VERSION=4.0.0-rc.12
+    - env: IMMUTABLE_VERSION=4.0.0-rc.12
 
 # Identifies `a.b.c-xxx.n` tags as pre-releases, and `a.b.c` as stable releases
 before_deploy: |

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,9 +23,9 @@ notifications:
     on_failure: always
 
 before_script:
-  - 'if [ "$IMMUTABLE_VERSION" ]; then npm install immutable@$IMMUTABLE_VERSION; fi'
+  - 'if [ "$IMMUTABLE_VERSION" ]; then yarn add immutable@$IMMUTABLE_VERSION; fi'
 env:
-  - IMMUTABLE_VERSION=3
+  - IMMUTABLE_VERSION=
   - IMMUTABLE_VERSION=4.0.0-rc.12
 # Identifies `a.b.c-xxx.n` tags as pre-releases, and `a.b.c` as stable releases
 before_deploy: |

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,15 @@ os:
   - linux
   - osx
 
+matrix:
+  include:
+    - env: IMMUTABLE_VERSION=^4.0.0-rc
+
 install:
   - yarn install --frozen-lockfile
+
+before_script:
+  - if [ "$IMMUTABLE_VERSION" ]; then yarn add --dev immutable@$IMMUTABLE_VERSION; fi
 
 after_script:
   - if [[ "$TRAVIS_OS_NAME" == "linux" && "$TRAVIS_NODE_VERSION" == "11" ]]; then yarn coveralls; fi
@@ -21,13 +28,6 @@ notifications:
   email:
     on_success: never
     on_failure: always
-
-before_script:
-  - 'if [ "$IMMUTABLE_VERSION" ]; then yarn add immutable@$IMMUTABLE_VERSION; fi'
-
-matrix:
-  include:
-    - env: IMMUTABLE_VERSION=4.0.0-rc.12
 
 # Identifies `a.b.c-xxx.n` tags as pre-releases, and `a.b.c` as stable releases
 before_deploy: |

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,11 @@ notifications:
     on_success: never
     on_failure: always
 
+before_script:
+  - 'if [ "$IMMUTABLE_VERSION" ]; then npm install immutable@$IMMUTABLE_VERSION; fi'
+env:
+  - IMMUTABLE_VERSION=3
+  - IMMUTABLE_VERSION=4.0.0-rc.12
 # Identifies `a.b.c-xxx.n` tags as pre-releases, and `a.b.c` as stable releases
 before_deploy: |
   function dist_tag() {

--- a/chai-immutable.js
+++ b/chai-immutable.js
@@ -13,6 +13,14 @@
     context.chai.use(factory(context.Immutable));
   }
 })(this, Immutable => (chai, utils) => {
+  function isImmutable(value) {
+    if (typeof Immutable.isImmutable === 'undefined') {
+      return Immutable.Iterable.isIterable(value);
+    } else {
+      return Immutable.isImmutable(value);
+    }
+  }
+
   const { Assertion } = chai;
 
   function assertIsIterable(obj) {
@@ -95,11 +103,11 @@
    * @api public
    */
 
-  function assertCollectionEqual(_super) {
+  function assertImmutableEqual(_super) {
     return function(collection) {
       const obj = this._obj;
 
-      if (Immutable.Iterable.isIterable(obj)) {
+      if (isImmutable(obj)) {
         this.assert(
           Immutable.is(obj, collection),
           'expected #{act} to equal #{exp}',
@@ -114,11 +122,11 @@
     };
   }
 
-  Assertion.overwriteMethod('equal', assertCollectionEqual);
-  Assertion.overwriteMethod('equals', assertCollectionEqual);
-  Assertion.overwriteMethod('eq', assertCollectionEqual);
-  Assertion.overwriteMethod('eql', assertCollectionEqual);
-  Assertion.overwriteMethod('eqls', assertCollectionEqual);
+  Assertion.overwriteMethod('equal', assertImmutableEqual);
+  Assertion.overwriteMethod('equals', assertImmutableEqual);
+  Assertion.overwriteMethod('eq', assertImmutableEqual);
+  Assertion.overwriteMethod('eql', assertImmutableEqual);
+  Assertion.overwriteMethod('eqls', assertImmutableEqual);
 
   /**
    * ### .include(value)


### PR DESCRIPTION
Copies isImmutable function from #83, but no conflicts and check for isImmutable only for .equal. Other places have valid checks for isIterable (.empty or .size is not available in Record)