### PR TITLE
Implement reference comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,12 +122,30 @@ expect(a).to.equal(b);
 Immutable data structures should only contain other immutable data
 structures (unlike `Array`s and `Object`s) to be considered immutable and
 properly work against `.equal()`. See
-[this issue](https://github.com/astorije/chai-immutable/issues/24) for
-more information.
+[issue #24](https://github.com/astorije/chai-immutable/issues/24) for more
+information.
 
 Also, note that `deep.equal` and `eql` are synonyms of `equal` when
 tested against immutable data structures, therefore they are aliases to
 `equal`.
+
+### .referenceEqual(value)
+
+- **@param** _{Collection}_ value
+
+Asserts that the reference of the target is equivalent to the reference of
+`collection`. This method preserves the original behavior of Chai's `equal`.
+
+See [issue #210](https://github.com/astorije/chai-immutable/issues/210) for
+more details.
+
+```js
+const a = List.of(1, 2, 3);
+const b = a;
+const c = List.of(1, 2, 3);
+expect(a).to.referenceEqual(b);
+expect(a).to.not.referenceEqual(c);
+```
 
 ### .include(value)
 
@@ -385,8 +403,27 @@ assert.equal(a, b);
 Immutable data structures should only contain other immutable data
 structures (unlike `Array`s and `Object`s) to be considered immutable and
 properly work against `.equal()`, `.strictEqual()` or `.deepEqual()`. See
-[this issue](https://github.com/astorije/chai-immutable/issues/24) for
-more information.
+[issue #24](https://github.com/astorije/chai-immutable/issues/24) for more
+information.
+
+### .referenceEqual(actual, expected)
+
+- **@param** _{Collection}_ actual
+- **@param** _{Collection}_ expected
+
+Asserts that the reference of `actual` is equivalent to the reference of
+`expected`. This method preserves the original behavior of Chai's `equal`.
+
+See [issue #210](https://github.com/astorije/chai-immutable/issues/210) for
+more details.
+
+```js
+const a = List.of(1, 2, 3);
+const b = a;
+const c = List.of(1, 2, 3);
+assert.referenceEqual(a, b);
+assert.throws(() => assert.referenceEqual(a, c));
+```
 
 ### .notEqual(actual, expected)
 
@@ -401,6 +438,25 @@ exactly like `.notEqual()` in the context of Immutable data structures.
 const a = List.of(1, 2, 3);
 const b = List.of(4, 5, 6);
 assert.notEqual(a, b);
+```
+
+### .notReferenceEqual(actual, expected)
+
+- **@param** _{Collection}_ actual
+- **@param** _{Collection}_ expected
+
+Asserts that the reference of `actual` is not equivalent to the reference of
+`expected`. This method preserves the original behavior of Chai's `notEqual`.
+
+See [issue #210](https://github.com/astorije/chai-immutable/issues/210) for
+more details.
+
+```js
+const a = List.of(1, 2, 3);
+const b = a;
+const c = List.of(1, 2, 3);
+assert.throws(() => assert.notReferenceEqual(a, b));
+assert.notReferenceEqual(a, c);
 ```
 
 ### .sizeOf(collection, length)

--- a/chai-immutable.js
+++ b/chai-immutable.js
@@ -839,6 +839,31 @@
   };
 
   /**
+   * ### .referenceEqual(actual, expected)
+   *
+   * Asserts that the reference of `actual` is equivalent to the reference of
+   * `expected`. This method preserves the original behavior of chai's equal.
+   *
+   * Reasons for this are described in #210.
+   *
+   * ```js
+   * const a = List.of(1, 2, 3);
+   * const b = a
+   * const c = List.of(1, 2, 3);
+   * assert.equal(a, b); // true
+   * assert.equal(a, c); // false
+   * ```
+   *
+   * @name referenceEqual
+   * @param {Collection} actual
+   * @param {Collection} expected
+   * @namespace Assert
+   * @api public
+   */
+
+  assert.referenceEqual = originalEqual;
+
+  /**
    * ### .notEqual(actual, expected)
    *
    * Asserts that the values of `actual` are not equivalent to the values of

--- a/chai-immutable.js
+++ b/chai-immutable.js
@@ -892,6 +892,31 @@
   };
 
   /**
+   * ### .referenceNotEqual(actual, expected)
+   *
+   * Asserts that the reference of `actual` is not equivalent to the reference of
+   * `expected`. This method preserves the original behavior of chai's notEqual.
+   *
+   * Reasons for this are described in #210.
+   *
+   * ```js
+   * const a = List.of(1, 2, 3);
+   * const b = a
+   * const c = List.of(1, 2, 3);
+   * assert.referenceNotEqual(a, b); // false
+   * assert.referenceNotEqual(a, c); // true
+   * ```
+   *
+   * @name referenceEqual
+   * @param {Collection} actual
+   * @param {Collection} expected
+   * @namespace Assert
+   * @api public
+   */
+
+  assert.referenceNotEqual = originalNotEqual;
+
+  /**
    * ### .sizeOf(collection, length)
    *
    * Asserts that the immutable collection has the expected size.

--- a/chai-immutable.js
+++ b/chai-immutable.js
@@ -124,16 +124,16 @@
    * ### .referenceEqual(value)
    *
    * Asserts that the reference of the target is equivalent to the reference of
-   * `collection`. This method preserves the original behavior of chai's equal.
+   * `collection`. This method preserves the original behavior of Chai's `equal`.
    *
-   * Reasons for this are described in #210.
+   * See https://github.com/astorije/chai-immutable/issues/210 for more details.
    *
    * ```js
    * const a = List.of(1, 2, 3);
-   * const b = a
+   * const b = a;
    * const c = List.of(1, 2, 3);
-   * expect(a).to.referenceEqual(b); // true
-   * expect(a).to.referenceEqual(c); // false
+   * expect(a).to.referenceEqual(b);
+   * expect(a).to.not.referenceEqual(c);
    * ```
    *
    * @name referenceEqual
@@ -842,16 +842,16 @@
    * ### .referenceEqual(actual, expected)
    *
    * Asserts that the reference of `actual` is equivalent to the reference of
-   * `expected`. This method preserves the original behavior of chai's equal.
+   * `expected`. This method preserves the original behavior of Chai's `equal`.
    *
-   * Reasons for this are described in #210.
+   * See https://github.com/astorije/chai-immutable/issues/210 for more details.
    *
    * ```js
    * const a = List.of(1, 2, 3);
-   * const b = a
+   * const b = a;
    * const c = List.of(1, 2, 3);
-   * assert.equal(a, b); // true
-   * assert.equal(a, c); // false
+   * assert.referenceEqual(a, b);
+   * assert.throws(() => assert.referenceEqual(a, c));
    * ```
    *
    * @name referenceEqual
@@ -892,29 +892,29 @@
   };
 
   /**
-   * ### .referenceNotEqual(actual, expected)
+   * ### .notReferenceEqual(actual, expected)
    *
    * Asserts that the reference of `actual` is not equivalent to the reference of
-   * `expected`. This method preserves the original behavior of chai's notEqual.
+   * `expected`. This method preserves the original behavior of Chai's `notEqual`.
    *
-   * Reasons for this are described in #210.
+   * See https://github.com/astorije/chai-immutable/issues/210 for more details.
    *
    * ```js
    * const a = List.of(1, 2, 3);
-   * const b = a
+   * const b = a;
    * const c = List.of(1, 2, 3);
-   * assert.referenceNotEqual(a, b); // false
-   * assert.referenceNotEqual(a, c); // true
+   * assert.throws(() => assert.notReferenceEqual(a, b));
+   * assert.notReferenceEqual(a, c);
    * ```
    *
-   * @name referenceEqual
+   * @name notReferenceEqual
    * @param {Collection} actual
    * @param {Collection} expected
    * @namespace Assert
    * @api public
    */
 
-  assert.referenceNotEqual = originalNotEqual;
+  assert.notReferenceEqual = originalNotEqual;
 
   /**
    * ### .sizeOf(collection, length)

--- a/chai-immutable.js
+++ b/chai-immutable.js
@@ -77,8 +77,8 @@
    * Immutable data structures should only contain other immutable data
    * structures (unlike `Array`s and `Object`s) to be considered immutable and
    * properly work against `.equal()`. See
-   * [this issue](https://github.com/astorije/chai-immutable/issues/24) for
-   * more information.
+   * [issue #24](https://github.com/astorije/chai-immutable/issues/24) for more
+   * information.
    *
    * Also, note that `deep.equal` and `eql` are synonyms of `equal` when
    * tested against immutable data structures, therefore they are aliases to
@@ -126,7 +126,8 @@
    * Asserts that the reference of the target is equivalent to the reference of
    * `collection`. This method preserves the original behavior of Chai's `equal`.
    *
-   * See https://github.com/astorije/chai-immutable/issues/210 for more details.
+   * See [issue #210](https://github.com/astorije/chai-immutable/issues/210) for
+   * more details.
    *
    * ```js
    * const a = List.of(1, 2, 3);
@@ -817,8 +818,8 @@
    * Immutable data structures should only contain other immutable data
    * structures (unlike `Array`s and `Object`s) to be considered immutable and
    * properly work against `.equal()`, `.strictEqual()` or `.deepEqual()`. See
-   * [this issue](https://github.com/astorije/chai-immutable/issues/24) for
-   * more information.
+   * [issue #24](https://github.com/astorije/chai-immutable/issues/24) for more
+   * information.
    *
    * @name equal
    * @param {Collection} actual
@@ -844,7 +845,8 @@
    * Asserts that the reference of `actual` is equivalent to the reference of
    * `expected`. This method preserves the original behavior of Chai's `equal`.
    *
-   * See https://github.com/astorije/chai-immutable/issues/210 for more details.
+   * See [issue #210](https://github.com/astorije/chai-immutable/issues/210) for
+   * more details.
    *
    * ```js
    * const a = List.of(1, 2, 3);
@@ -897,7 +899,8 @@
    * Asserts that the reference of `actual` is not equivalent to the reference of
    * `expected`. This method preserves the original behavior of Chai's `notEqual`.
    *
-   * See https://github.com/astorije/chai-immutable/issues/210 for more details.
+   * See [issue #210](https://github.com/astorije/chai-immutable/issues/210) for
+   * more details.
    *
    * ```js
    * const a = List.of(1, 2, 3);

--- a/chai-immutable.js
+++ b/chai-immutable.js
@@ -121,6 +121,45 @@
   Assertion.overwriteMethod('eqls', assertCollectionEqual);
 
   /**
+   * ### .referenceEqual(value)
+   *
+   * Asserts that the reference of the target is equivalent to the reference of
+   * `collection`. This method preserves the original behavior of chai's equal.
+   *
+   * Reasons for this are described in #210.
+   *
+   * ```js
+   * const a = List.of(1, 2, 3);
+   * const b = a
+   * const c = List.of(1, 2, 3);
+   * expect(a).to.referenceEqual(b); // true
+   * expect(a).to.referenceEqual(c); // false
+   * ```
+   *
+   * @name referenceEqual
+   * @param {Collection} value
+   * @namespace BDD
+   * @api public
+   */
+
+  function assertCollectionReferenceEqual() {
+    return function(collection) {
+      const obj = this._obj;
+
+      this.assert(
+        obj === collection,
+        'expected #{act} reference to equal #{exp}',
+        'expected #{act} reference to not equal #{exp}',
+        collection.toJS(),
+        obj.toJS(),
+        true
+      );
+    };
+  }
+
+  Assertion.addMethod('referenceEqual', assertCollectionReferenceEqual);
+
+  /**
    * ### .include(value)
    *
    * The `include` and `contain` assertions can be used as either property

--- a/test/test.js
+++ b/test/test.js
@@ -993,19 +993,19 @@ describe('chai-immutable', function() {
       });
     });
 
-    describe('referenceNotEqual assertion', function() {
+    describe('notReferenceEqual assertion', function() {
       it('should pass for different immutable collections with equal values', function() {
         const list1 = List.of(1, 2, 3);
         const list2 = List.of(1, 2, 3);
 
-        assert.referenceNotEqual(list1, list2);
+        assert.notReferenceEqual(list1, list2);
       });
 
       it('should not pass for different immutable collections with equal values', function() {
         const list1 = List.of(1, 2, 3);
         const list2 = list1;
 
-        fail(() => assert.referenceNotEqual(list1, list2));
+        fail(() => assert.notReferenceEqual(list1, list2));
       });
     });
 

--- a/test/test.js
+++ b/test/test.js
@@ -993,6 +993,22 @@ describe('chai-immutable', function() {
       });
     });
 
+    describe('referenceNotEqual assertion', function() {
+      it('should pass for different immutable collections with equal values', function() {
+        const list1 = List.of(1, 2, 3);
+        const list2 = List.of(1, 2, 3);
+
+        assert.referenceNotEqual(list1, list2);
+      });
+
+      it('should not pass for different immutable collections with equal values', function() {
+        const list1 = List.of(1, 2, 3);
+        const list2 = list1;
+
+        fail(() => assert.referenceNotEqual(list1, list2));
+      });
+    });
+
     describe('unoverridden strictEqual and deepEqual assertions', function() {
       it('should pass given equal values', function() {
         assert.strictEqual(list3, List.of(1, 2, 3));

--- a/test/test.js
+++ b/test/test.js
@@ -186,6 +186,22 @@ describe('chai-immutable', function() {
       });
     });
 
+    describe('referenceEqual method', function() {
+      it('should pass for equal references', function() {
+        const list1 = List.of(1, 2, 3);
+        const list2 = list1;
+
+        expect(list1).to.referenceEqual(list2);
+      });
+
+      it('should not pass for different immutable collections with equal values', function() {
+        const list1 = List.of(1, 2, 3);
+        const list2 = List.of(1, 2, 3);
+
+        expect(list1).to.not.referenceEqual(list2);
+      });
+    });
+
     describe('include method', function() {
       it('should pass given an existing value', function() {
         expect(new List([1, 2, 3])).to.include(2);

--- a/test/test.js
+++ b/test/test.js
@@ -946,6 +946,22 @@ describe('chai-immutable', function() {
       });
     });
 
+    describe('referenceEqual assertion', function() {
+      it('should pass for equal references', function() {
+        const list1 = List.of(1, 2, 3);
+        const list2 = list1;
+
+        assert.referenceEqual(list1, list2);
+      });
+
+      it('should not pass for different immutable collections with equal values', function() {
+        const list1 = List.of(1, 2, 3);
+        const list2 = List.of(1, 2, 3);
+
+        fail(() => assert.referenceEqual(list1, list2));
+      });
+    });
+
     describe('notEqual assertion', function() {
       it('should pass given different values', function() {
         assert.notEqual(list3, new List());


### PR DESCRIPTION
This MR adds `referenceEqual` BDD method and `referenceEqual` and `referenceNotEqual` TDD methods according to the discussion in #210.

Close #210.